### PR TITLE
Fix variable name 'asm' -> 'qpasm' for c++ and some bugs of examples

### DIFF
--- a/example/nurbs/nurbs_nn_test.c
+++ b/example/nurbs/nurbs_nn_test.c
@@ -34,7 +34,7 @@ void nn_test(zNURBS *nurbs)
 void output_src(zSeq *seq)
 {
   FILE *fp;
-  zSeqListCell *cp;
+  zSeqCell *cp;
 
   fp = fopen( "src", "w" );
   zListForEach( seq, cp )

--- a/example/nurbs/nurbs_test.c
+++ b/example/nurbs/nurbs_test.c
@@ -26,7 +26,7 @@ void test_weight(zNURBS *nurbs, int w)
 void output_src(zSeq *seq)
 {
   FILE *fp;
-  zSeqListCell *cp;
+  zSeqCell *cp;
 
   fp = fopen( "src", "w" );
   zListForEach( seq, cp )

--- a/example/opt/qp_test.c
+++ b/example/opt/qp_test.c
@@ -24,7 +24,7 @@ int main(void)
   zMatPrint( q );
   zMatPrint( a );
   zVecPrint( b );
-  zQPSolve( q, z, a, b, x, &cost );
+  zQPSolveASM( q, z, a, b, x, &cost );
   zVecPrint( x );
 
   zMatFree( q );

--- a/example/seq/seq_del_test.c
+++ b/example/seq/seq_del_test.c
@@ -6,7 +6,7 @@ int main(void)
 {
   zSeq seq;
   zVec v;
-  zSeqListCell *cp;
+  zSeqCell *cp;
   double t = 0;
   int i;
 
@@ -20,7 +20,7 @@ int main(void)
     printf( "%g ", t );
     zVecPrint( cp->data.v );
     t += cp->data.dt;
-    zSeqListCellFree( cp );
+    zSeqCellFree( cp );
   }
   return 0;
 }

--- a/example/seq/seq_jump_test.c
+++ b/example/seq/seq_jump_test.c
@@ -3,7 +3,7 @@
 int main(void)
 {
   zSeq seq;
-  zSeqListCell *cp;
+  zSeqCell *cp;
   int i;
 
   zSeqScanFile( &seq, "test" );

--- a/example/stat/perm_test.c
+++ b/example/stat/perm_test.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[])
   n1 = argc > 1 ? atof(argv[1]) : N1;
   n2 = argc > 2 ? atof(argv[2]) : N2;
   printf( "%d_P_%d = %f\n", n1, n2, zPermut( n1, n2 ) );
-  printf( "%d! = %f\n", n1, zFacto( n1 ) );
+  printf( "%d! = %f\n", n1, zFactorial( n1 ) );
   printf( "%d_C_%d = %f\n", n1, n2, zCombi( n1, n2 ) );
   return 0;
 }


### PR DESCRIPTION
I was building for C++ and noticed a compilation error in src/zm_opt_qp_asm.c.  
The keyword "asm" is a special keyword in C++.  
So, I replaced "asm" -> "qpasm" so that the compilation would pass.  

In addition, I fixed some bugs in the example code related to zSeq and zFactoreal().

Please check the changes.