### PR TITLE
Fix bug 'zLE' -> 'zLEWorkspace' in example/le_sr_nullspace_test.c

### DIFF
--- a/example/le/le_sr_nullspace_test.c
+++ b/example/le/le_sr_nullspace_test.c
@@ -16,13 +16,13 @@ void check(zMat a, zVec b, zVec ans, zVec e, const char *key)
 
 void test(zMat a, zVec b, zVec w, zVec w2, zVec e, zVec aux)
 {
-  zLE le;
+  zLEWorkspace le;
   zVec x1, x2, bb;
 
   x1 = zVecAlloc( N );
   x2 = zVecAlloc( N );
   bb = zVecAlloc( zVecSizeNC(b) );
-  zLEAlloc( &le, NULL, N );
+  zLEWorkspaceAlloc( &le, NULL, N );
   zVecRandUniform( aux, -10, 10 );
 
   zLESolveSRAux( a, b, w, w2, x1, aux );
@@ -32,7 +32,7 @@ void test(zMat a, zVec b, zVec w, zVec w2, zVec e, zVec aux)
   zVecSub( x1, x2, le.s );
   printf( "error = %.10g\n", zVecNorm(le.s) );
 
-  zLEFree( &le );
+  zLEWorkspaceFree( &le );
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
As the title suggests, there was a typo in the sample code le_sr_nullspace_test.c, so I fixed it.  
Please check and merge.  