### PR TITLE
Fix 'ZM_ERR_NONSQR_MAT' -> 'ZM_ERR_MAT_NOTSQR' in example/le/matdecomp_benchmark_test.c

### DIFF
--- a/example/le/matdecomp_benchmark_test.c
+++ b/example/le/matdecomp_benchmark_test.c
@@ -53,7 +53,7 @@ bool test_qqt(zMat m)
   register int i, j;
 
   if( !zMatIsSqr( m ) ){
-    ZRUNWARN( ZM_ERR_NONSQR_MAT );
+    ZRUNWARN( ZM_ERR_MAT_NOTSQR );
     return false;
   }
   for( i=0; i<zMatRowSizeNC(m); i++ )


### PR DESCRIPTION
As the title says. Fixed one bug in the sample code. 
Please check and merge.