### PR TITLE
Fixed missing changes in renamed APIs

### DIFF
--- a/example/eig/eigsys_large_test.c
+++ b/example/eig/eigsys_large_test.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
 
   /* ensurance */
   cma = zCMatAlloc( n, n );
-  zMat2CMat( ma, cma );
+  zMatToCMat( ma, cma );
   vt = zCVecAlloc( n );
   for( i=0; i<n; i++ ){
     printf( "eig.#%d val= ", i );

--- a/example/eig/eigsys_test.c
+++ b/example/eig/eigsys_test.c
@@ -108,7 +108,7 @@ int main(void)
 
   /* ensurance */
   cma = zCMatAlloc( n, n );
-  zMat2CMat( ma, cma );
+  zMatToCMat( ma, cma );
   vt = zCVecAlloc( n );
   for( i=0; i<n; i++ ){
     printf( "eig.#%d val= ", i );

--- a/example/le/le_benchmark_test.c
+++ b/example/le/le_benchmark_test.c
@@ -31,28 +31,28 @@ int main(void)
     zMatAdj( a, aa );
     zMatDivDRC( aa, zMatDet(a) );
     zMulMatVec( aa, b, x );
-    if( !zVecIsEqual( x, ans, TOL ) ){
+    if( !zVecEqual( x, ans, TOL ) ){
       count_cramel++;
     }
     /* Gauss's elimination method */
     zLESolveGauss( a, b, x );
-    if( !zVecIsEqual( x, ans, TOL ) ){
+    if( !zVecEqual( x, ans, TOL ) ){
       count_gauss++;
     }
     /* LU decomposition method */
     zMatDecompLU( a, l, u, index );
     zLESolveLU( l, u, b, x, index );
-    if( !zVecIsEqual( x, ans, TOL ) ){
+    if( !zVecEqual( x, ans, TOL ) ){
       count_lu++;
     }
     /* Residual iteration method */
     zLESolveRI( a, b, x );
-    if( !zVecIsEqual( x, ans, TOL ) ){
+    if( !zVecEqual( x, ans, TOL ) ){
       count_ri++;
     }
     /* Gauss-Seidel's method */
     zLESolveGS( a, b, x );
-    if( !zVecIsEqual( x, ans, TOL ) ){
+    if( !zVecEqual( x, ans, TOL ) ){
       count_gs++;
     }
   }

--- a/example/vec/vec_ring_cat_test.c
+++ b/example/vec/vec_ring_cat_test.c
@@ -19,7 +19,7 @@ int main(void)
     printf( "v_%d: ", i ); zVecPrint( *zRingElem(&v,i) );
   }
   printf( "k: " ); zVecPrint( k );
-  zVecRingLS( s, k, &v );
+  zVecRingLinearSum( s, k, &v );
   zVecPrint( s );
   zVecRingFree( &v );
   return 0;


### PR DESCRIPTION
As the title, I fixed missing changes in renamed APIs `zMat2CMat()` -> `zMatToCMat()` , `zVecIsEqual()` -> `zVecEqual()` , `zVecRingLS()` -> `zVecRingLinearSum()` .