### PR TITLE
Add zNURBSClone API

### DIFF
--- a/include/zm/zm_nurbs.h
+++ b/include/zm/zm_nurbs.h
@@ -148,6 +148,13 @@ __ZM_EXPORT bool zNURBSCreate(zNURBS *nurbs, const zSeq *seq, int order);
  */
 __ZM_EXPORT void zNURBSDestroy(zNURBS *nurbs);
 
+/*! \brief clone a NURBS curve.
+ *
+ * zNURBSClone() clones \a src of NURBS curve into \a dest.
+ * In previous, \a dest must be initialized by zNURBSInit().
+ */
+__ZM_EXPORT void zNURBSClone(const zNURBS *src, zNURBS *dest)
+
 /*! \brief normalize the knot vector of a NURBS curve.
  *
  * zNURBSKnotNormalize() normalizes the knot vector of a

--- a/src/zm_nurbs.c
+++ b/src/zm_nurbs.c
@@ -181,6 +181,23 @@ void zNURBSDestroy(zNURBS *nurbs)
   zArrayFree( &nurbs->cparray );
 }
 
+/* clone a NURBS curve. */
+void zNURBSClone(const zNURBS *src, zNURBS *dest)
+{
+  int i, cp_size;
+
+  zBSplineParamAlloc( &dest->param, src->param.order, zArraySize( &src->cparray ), 0 );
+  zArrayAlloc( &dest->cparray, zNURBSCPCell, zArraySize( &src->cparray ) );
+  zBSplineParamCopy( &src->param, &dest->param );
+  if( zNURBSCPNum( src ) > 0 )
+    cp_size = zVecSize( zNURBSCP( src, 0 ) );
+  for( i=0; i < zNURBSCPNum( src ); i++ ){
+    zNURBSSetWeight( dest, i, zNURBSWeight( src, i ) );
+    zNURBSCP( dest, i ) = zVecAlloc( cp_size );
+    zVecCopy( zNURBSCP( src, i ), zNURBSCP( dest, i ) );
+  }
+}
+
 /* compute a vector on a NURBS curve. */
 zVec zNURBSVec(const zNURBS *nurbs, double t, zVec v)
 {


### PR DESCRIPTION
As stated in the title, I would like to propose adding an API `zNURBSClone` to clone a zNURBS.   
I would appreciate your consideration in merging the same function as this.  